### PR TITLE
Added HL TCP Timeout

### DIFF
--- a/Networking/src/Makefile
+++ b/Networking/src/Makefile
@@ -23,6 +23,9 @@ library.o:
 library: server.o  client.o tcpserver.o tcpclient.o library.o
 	$(CC) $(LINK)  tcpserver.o server.o client.o tcpclient.o library.o  -L/lib64/ -o libNetwork.so && cp 'libNetwork.so' ../../Assets/Plugins/Network.so
 
+server: server.o  client.o tcpserver.o tcpclient.o library.o
+	$(CC) $(LINK)  tcpserver.o server.o client.o tcpclient.o library.o  -L/lib64/ -o libNetwork.so && cp 'libNetwork.so' /usr/lib/libNetwork.so
+
 #library: server.o library.o client.o tcpserver.o tcpclient.o
 # 	$(CC) $(LINK) library.o tcpserver.o server.o client.o -o libNetwork.so && cp 'libNetwork.so' ../../Assets/Plugins/Network.so
 

--- a/Networking/src/library.cpp
+++ b/Networking/src/library.cpp
@@ -70,9 +70,9 @@ extern "C" TCPServer * TCPServer_CreateServer()
 	return new TCPServer();
 }
 
-extern "C" int32_t TCPServer_initServer(void * serverPtr, short port)
+extern "C" int32_t TCPServer_initServer(void * serverPtr, short port, short timeout)
 {
-	return ((TCPServer *)serverPtr)->initializeSocket(port);
+	return ((TCPServer *)serverPtr)->initializeSocket(port, timeout);
 }
 
 extern "C" int32_t TCPServer_acceptConnection(void * serverPtr, EndPoint * ep)

--- a/Networking/src/tcpserver.cpp
+++ b/Networking/src/tcpserver.cpp
@@ -93,7 +93,7 @@ TCPServer::TCPServer()
  * initialize, errno when the socket fails to bind, and the server's
  * listen socket descriptor on success.
  */
-int32_t TCPServer::initializeSocket	(short port)
+int32_t TCPServer::initializeSocket	(short port, short timeout)
 {
 	struct	sockaddr_in server;
 	if ((tcpSocket = socket(AF_INET, SOCK_STREAM, 0)) == -1)
@@ -103,15 +103,16 @@ int32_t TCPServer::initializeSocket	(short port)
 	}
 	int optFlag = 1;
 
-	// Sets server receive timeout to 30 seconds.
+	// Sets server receive timeout to input timeout seconds.
 	struct timeval tv;
-	tv.tv_sec = 30;
+	tv.tv_sec = timeout;
 	tv.tv_usec = 0;
 
 	if (setsockopt(tcpSocket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(struct timeval)) == -1)
 	{
 		perror("Failed to setsockopt: timeout");
 	}
+	fprintf(stderr, "Timeout set to: %ld\n", tv.tv_sec);
 
 	// Set socket to reuse address
 	if (setsockopt(tcpSocket, SOL_SOCKET, SO_REUSEADDR, &optFlag, sizeof(optFlag)) == -1)
@@ -153,7 +154,7 @@ int32_t TCPServer::initializeSocket	(short port)
  * DATE:		Mar.
  *
  * REVISIONS:	Mar.
- * 				Apr.
+ * 				Apr. 9 (added timeout), 10, 11 (init takes timeout)
  *
  * DESIGNER:	Delan Elliot, Wilson Hu, Matthew Shew
  *

--- a/Networking/src/tcpserver.h
+++ b/Networking/src/tcpserver.h
@@ -36,7 +36,7 @@ class TCPServer {
 
 public:
 	TCPServer();
-	int32_t initializeSocket(short port);
+	int32_t initializeSocket(short port, short timeout);
 	int32_t acceptConnection(EndPoint* ep);
 	int32_t sendBytes(int clientSocket, char * data, unsigned len);
 	int32_t receiveBytes(int clientSocket, char * buffer, unsigned len);


### PR DESCRIPTION
Modified TCP Init function to take a timeout value. 
Timeout value is set in TCPServer::initializeSocket, and is passed down from initTCPServer in server.cs (server repo). 

Timeout value can be set in R.Net.TIMEOUT